### PR TITLE
v0.5.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -6,8 +6,8 @@ if errorlevel 1 exit 1
 cp ml_dtypes\include\float8.h %LIBRARY_PREFIX%\include\ml_dtypes\include\float8.h
 if errorlevel 1 exit 1
 
-cp ml_dtypes\include\int4.h %LIBRARY_PREFIX%\include\ml_dtypes\include\int4.h
+cp ml_dtypes\include\mxfloat.h %LIBRARY_PREFIX%\include\ml_dtypes\include\mxfloat.h
 if errorlevel 1 exit 1
 
-cp ml_dtypes\include\int4.h %LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h
+cp ml_dtypes\include\mxfloat.h %LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,5 +5,5 @@ set -euxo pipefail
 mkdir -p $PREFIX/include/ml_dtypes/include
 
 cp ml_dtypes/include/float8.h $PREFIX/include/ml_dtypes/include/float8.h
-cp ml_dtypes/include/int4.h $PREFIX/include/ml_dtypes/include/int4.h
+cp ml_dtypes/include/mxfloat.h $PREFIX/include/ml_dtypes/include/mxfloat.h
 cp ml_dtypes/include/intn.h $PREFIX/include/ml_dtypes/include/intn.h

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,16 @@ package:
 source:
   url: https://github.com/jax-ml/ml_dtypes/archive/v{{ version }}.tar.gz
   sha256: 78332f6043df9e89f837a218cc127cf3d244a1cc3ae34dc6af916925be25e371
+  patches:
+    - patches/0001-Fix-relative-import.patch
 
 build:
   number: 0
+
+requirements:
+  build:
+    - patch     # [unix]
+    - m2-patch  # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "libml_dtypes-headers" %}
-{% set version = "0.4.0" %}
+{% set version = "0.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,19 @@ package:
 
 source:
   url: https://github.com/jax-ml/ml_dtypes/archive/v{{ version }}.tar.gz
-  sha256: f50ed095a4c262b2d4cddc9ec22fc571b698f37008f12ea62e17a7ea43c7b458
+  sha256: 78332f6043df9e89f837a218cc127cf3d244a1cc3ae34dc6af916925be25e371
 
 build:
   number: 0
 
 test:
   commands:
-    - test -f ${PREFIX}/include/ml_dtypes/include/float8.h  # [unix]
-    - test -f ${PREFIX}/include/ml_dtypes/include/int4.h    # [unix]
-    - test -f ${PREFIX}/include/ml_dtypes/include/intn.h    # [unix]
-    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\float8.h (exit 1)  # [win]
-    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\int4.h (exit 1)    # [win]
-    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h (exit 1)    # [win]
+    - test -f ${PREFIX}/include/ml_dtypes/include/float8.h   # [unix]
+    - test -f ${PREFIX}/include/ml_dtypes/include/mxfloat.h  # [unix]
+    - test -f ${PREFIX}/include/ml_dtypes/include/intn.h     # [unix]
+    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\float8.h (exit 1)   # [win]
+    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\mxfloat.h (exit 1)  # [win]
+    - if not exist %LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h (exit 1)     # [win]
 
 
 about:

--- a/recipe/patches/0001-Fix-relative-import.patch
+++ b/recipe/patches/0001-Fix-relative-import.patch
@@ -1,0 +1,27 @@
+From 909d99c3d9a72571c0d6b7aee89fdcbc7ca8503b Mon Sep 17 00:00:00 2001
+From: Eric Lundby <Eric.Lundby@gmail.com>
+Date: Wed, 2 Apr 2025 14:04:43 -0600
+Subject: [PATCH 1/1] Fix-relative-import
+
+float8.h is next to mxfloat.h, just include it. 
+
+---
+ ml_dtypes/include/mxfloat.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ml_dtypes/include/mxfloat.h b/ml_dtypes/include/mxfloat.h
+index 252e835..50fb8f0 100644
+--- a/ml_dtypes/include/mxfloat.h
++++ b/ml_dtypes/include/mxfloat.h
+@@ -25,7 +25,7 @@ limitations under the License.
+ #include <cstdint>
+ #include <limits>
+ 
+-#include "include/float8.h"
++#include "float8.h"
+ #include "Eigen/Core"
+ 
+ namespace ml_dtypes {
+-- 
+2.39.5 (Apple Git-154)
+


### PR DESCRIPTION
lbml_dtypes-headers

**Destination channel:**  defaults

### Links

### Explanation of changes:

- Bump version and SHA
- Update to new header names.  
