### PR TITLE
Switch to native windows commands.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,13 +1,13 @@
 @echo on
 
-md %LIBRARY_PREFIX%\include\ml_dtypes\include
-if errorlevel 1 exit 1
+if not exist "%LIBRARY_PREFIX%\include\ml_dtypes\include\" mkdir "%LIBRARY_PREFIX%\include\ml_dtypes\include"
+if errorlevel 1 exit /b 1
 
-cp ml_dtypes\include\float8.h %LIBRARY_PREFIX%\include\ml_dtypes\include\float8.h
-if errorlevel 1 exit 1
+copy /Y ml_dtypes\include\float8.h "%LIBRARY_PREFIX%\include\ml_dtypes\include\float8.h"
+if errorlevel 1 exit /b 1
 
-cp ml_dtypes\include\mxfloat.h %LIBRARY_PREFIX%\include\ml_dtypes\include\mxfloat.h
-if errorlevel 1 exit 1
+copy /Y ml_dtypes\include\mxfloat.h "%LIBRARY_PREFIX%\include\ml_dtypes\include\mxfloat.h"
+if errorlevel 1 exit /b 1
 
-cp ml_dtypes\include\mxfloat.h %LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h
-if errorlevel 1 exit 1
+copy /Y ml_dtypes\include\intn.h "%LIBRARY_PREFIX%\include\ml_dtypes\include\intn.h"
+if errorlevel 1 exit /b 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,12 +12,7 @@ source:
     - patches/0001-Fix-relative-import.patch
 
 build:
-  number: 0
-
-requirements:
-  build:
-    - patch     # [unix]
-    - m2-patch  # [win]
+  number: 1
 
 test:
   commands:


### PR DESCRIPTION
libml_dtypes-headers — rebuild 

Use native Windows mkdir/copy in bld.bat instead of MSYS md/cp, and install intn.h from the correct upstream file (previously copied mxfloat.h). Drop *patch from build deps.

Fixes win-arm64: https://package-build.anaconda.com/v1/graph/69e9fecb-4bc7-4318-a3ec-514ab14460a7